### PR TITLE
Add S&P comparison data to table

### DIFF
--- a/portfoliosimskewedt.py
+++ b/portfoliosimskewedt.py
@@ -12,7 +12,7 @@ SIMULATION_YEARS = 40
 NUM_RUNS = 10_000
 
 # App version (update this on each change)
-APP_VERSION = "v1.3.0"
+APP_VERSION = "v1.3.1"
 
 # Default Stock model parameters (Hansen skew-t on log-returns)
 DEFAULT_SKEWT_NU = 7.0
@@ -434,7 +434,25 @@ def main():
             st.dataframe(summary_df)
 
             st.subheader("Negative Returns Analysis")
-            st.dataframe(negative_returns_df)
+            col_sim, col_sp = st.columns(2)
+            with col_sim:
+                st.markdown("Simulation")
+                st.dataframe(negative_returns_df)
+            with col_sp:
+                st.markdown("S&P comparison 1974-2024")
+                sp_index = [f"Under {p}%" for p in [10, 15, 20, 25, 30, 35, 40, 50]]
+                sp_values = [
+                    "12.5%",
+                    "10.0%",
+                    "7.5%",
+                    "5.0%",
+                    "2.5%",
+                    "2.5%",
+                    "0.0%",
+                    "0.0%",
+                ]
+                sp_df = pd.DataFrame({"S&P 1974-2024 (%)": sp_values}, index=sp_index)
+                st.dataframe(sp_df)
         else:
             st.info("Set your assumptions on the left and click 'Run Simulation'.")
 


### PR DESCRIPTION
Add S&P comparison data next to the negative returns simulation table to provide historical context.

---
<a href="https://cursor.com/background-agent?bcId=bc-3692c1fa-2561-465c-9128-2572dc06df8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3692c1fa-2561-465c-9128-2572dc06df8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

