### PR TITLE
Add under 45% row for sp comparison

### DIFF
--- a/portfoliosimskewedt.py
+++ b/portfoliosimskewedt.py
@@ -440,7 +440,7 @@ def main():
                 st.dataframe(negative_returns_df)
             with col_sp:
                 st.markdown("S&P comparison 1974-2024")
-                sp_index = [f"Under {p}%" for p in [10, 15, 20, 25, 30, 35, 40, 50]]
+                sp_index = [f"Under {p}%" for p in [10, 15, 20, 25, 30, 35, 40, 45, 50]]
                 sp_values = [
                     "12.5%",
                     "10.0%",
@@ -448,6 +448,7 @@ def main():
                     "5.0%",
                     "2.5%",
                     "2.5%",
+                    "0.0%",
                     "0.0%",
                     "0.0%",
                 ]


### PR DESCRIPTION
Add 'Under 45%: 0.0%' row to the S&P comparison table as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-d6f2e406-9eba-4c5d-a329-6270c108b2ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d6f2e406-9eba-4c5d-a329-6270c108b2ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

