### PR TITLE
Remove mobile section at bottom

### DIFF
--- a/portfoliosimskewedt.py
+++ b/portfoliosimskewedt.py
@@ -529,17 +529,6 @@ def main():
             )
             st.markdown('</div>', unsafe_allow_html=True)
             
-            # Add a compact mobile view for very small screens
-            with st.expander("📱 Compact Mobile View", expanded=False):
-                st.markdown("**Negative Returns Comparison**")
-                for i, threshold in enumerate([10, 15, 20, 25, 30, 35, 40, 45, 50]):
-                    st.markdown(f"""
-                    **Under {threshold}%:**
-                    - Stock Only: {negative_returns_df.iloc[i]["Stock Only (%)"]}
-                    - Portfolio: {negative_returns_df.iloc[i]["Overall Portfolio (%)"]}
-                    - Normal Model: {negative_returns_df.iloc[i]["Normal (same g, log vol) (%)"]}
-                    - S&P 1974-2024: {sp_values[i]}
-                    """)
         else:
             st.info("Set your assumptions on the left and click 'Run Simulation'.")
 


### PR DESCRIPTION
Remove the "Compact Mobile View" section because it was requested to be removed.

---
<a href="https://cursor.com/background-agent?bcId=bc-e47fe22f-aad8-4018-817e-0a3d00f5d715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e47fe22f-aad8-4018-817e-0a3d00f5d715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

