### PR TITLE
Add skew text label to histogram

### DIFF
--- a/portfoliosimskewedt.py
+++ b/portfoliosimskewedt.py
@@ -6,14 +6,14 @@ import numpy as np
 import pandas as pd
 import plotly.express as px
 from arch.univariate import SkewStudent
-from scipy.stats import norm
+from scipy.stats import norm, skew
 
 # --- Configuration ---
 SIMULATION_YEARS = 40
 NUM_RUNS = 10_000
 
 # App version (update this on each change)
-APP_VERSION = "v1.3.4"
+APP_VERSION = "v1.3.5"
 
 # Default Stock model parameters (Hansen skew-t on log-returns)
 DEFAULT_SKEWT_NU = 5.0
@@ -343,6 +343,7 @@ def generate_simulation_results(
     stock_median = np.median(flat)
     stock_mean = np.mean(flat)
     stock_std = np.std(flat)
+    stock_skew = skew(flat, bias=False)
     s_ql, s_qh = np.percentile(flat, [PLOT_CLIP_LOW, PLOT_CLIP_HIGH])
     stock_df = pd.DataFrame(flat[(flat >= s_ql) & (flat <= s_qh)], columns=["Annual Return"])
     stock_fig = px.histogram(stock_df, x="Annual Return", nbins=200, histnorm="percent")
@@ -373,7 +374,8 @@ def generate_simulation_results(
     stock_stat_labels = (
         f"Median: {stock_median:.2%}",
         f"Mean: {stock_mean:.2%}",
-        f"Std Dev: {stock_std:.2%}"
+        f"Std Dev: {stock_std:.2%}",
+        f"Skew: {stock_skew:.2f}"
     )
 
     return f"${median_val:,.0f}", f"{success_rate:.1f}%", f"{outperform_rate:.1f}%", fig, stock_fig, summary_percentiles_df, negative_returns_table, portfolio_stat_labels, stock_stat_labels


### PR DESCRIPTION
Add skew label to stock return histogram captions as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-c73ea58c-94de-415d-9e8f-11c2cc76bf37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c73ea58c-94de-415d-9e8f-11c2cc76bf37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

