### PR TITLE
Fix tab spacing and relabel kurtosis

### DIFF
--- a/portfoliosimskewedt.py
+++ b/portfoliosimskewedt.py
@@ -373,12 +373,12 @@ def generate_simulation_results(
         f"Std Dev: ${std_val:,.0f}"
     )
     stock_stat_labels = (
-		f"Median: {stock_median:.2%}",
-		f"Mean: {stock_mean:.2%}",
-		f"Std Dev: {stock_std:.2%}",
-		f"Skew: {stock_skew:.2f}",
-		f"Kurtosis: {stock_kurt:.2f}"
-	)
+        f"Median: {stock_median:.2%}",
+        f"Mean: {stock_mean:.2%}",
+        f"Std Dev: {stock_std:.2%}",
+        f"Skew: {stock_skew:.2f}",
+        f"Kurtosis (tailness): {stock_kurt:.2f}"
+    )
 
     return f"${median_val:,.0f}", f"{success_rate:.1f}%", f"{outperform_rate:.1f}%", fig, stock_fig, summary_percentiles_df, negative_returns_table, portfolio_stat_labels, stock_stat_labels
 
@@ -563,13 +563,13 @@ def main():
                 st.caption(p_std)
 
             st.plotly_chart(stock_fig, use_container_width=True)
-		# Small horizontal labels beneath stock returns histogram
-		# Support 4-5 labels (now includes Skew and Kurtosis)
-		labels = list(stock_stat_labels)
-		cols = st.columns(len(labels))
-		for col, label in zip(cols, labels):
-			with col:
-				st.caption(label)
+        # Small horizontal labels beneath stock returns histogram
+        # Support 4-5 labels (now includes Skew and Kurtosis)
+        labels = list(stock_stat_labels)
+        cols = st.columns(len(labels))
+        for col, label in zip(cols, labels):
+            with col:
+                st.caption(label)
             
         else:
             st.info("Set your assumptions on the left and click 'Run Simulation'.")


### PR DESCRIPTION
Fix tab indentation issues and relabel 'Kurtosis' to 'Kurtosis (tailness)' for clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-a396f606-83d6-4786-9717-47095c8d3b9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a396f606-83d6-4786-9717-47095c8d3b9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

