### PR TITLE
Add simulation years parameter to setup

### DIFF
--- a/portfoliosimskewedt.py
+++ b/portfoliosimskewedt.py
@@ -13,7 +13,7 @@ SIMULATION_YEARS = 50
 NUM_RUNS = 10_000
 
 # App version (update this on each change)
-APP_VERSION = "v1.3.7"
+APP_VERSION = "v1.3.8"
 
 # Default Stock model parameters (Hansen skew-t on log-returns)
 DEFAULT_SKEWT_NU = 5.0
@@ -401,7 +401,7 @@ def main():
         with st.expander("Initial Setup", expanded=True):
             start_value = st.number_input("Starting Value ($)", value=7_000_000, step=50_000, min_value=0)
             real_spending = st.number_input("Annual Real Spending ($)", value=150_000, step=1_000, min_value=0)
-            simulation_years = st.number_input("Simulation Years", value=50, step=1, min_value=1)
+            simulation_years = st.number_input("Simulation Years", value=SIMULATION_YEARS, step=1, min_value=1)
         with st.expander("Asset Allocation", expanded=True):
             stock_prop_percent = st.slider("Stock %", min_value=0, max_value=100, value=70, step=5)
         with st.expander("Economic Assumptions", expanded=True):


### PR DESCRIPTION
Use `SIMULATION_YEARS` constant for the default 'Simulation Years' input value to centralize its configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-6329d247-c858-4388-a8ea-e3d8ccf96c66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6329d247-c858-4388-a8ea-e3d8ccf96c66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

