### PR TITLE
Change return chart to line chart

### DIFF
--- a/portfoliosimskewedt.py
+++ b/portfoliosimskewedt.py
@@ -13,7 +13,7 @@ SIMULATION_YEARS = 50
 NUM_RUNS = 10_000
 
 # App version (update this on each change)
-APP_VERSION = "v1.3.11"
+APP_VERSION = "v1.3.12"
 
 # Default Stock model parameters (Hansen skew-t on log-returns)
 DEFAULT_SKEWT_NU = 5.0
@@ -496,12 +496,12 @@ def main():
                 "Percent": stock_pct + portfolio_pct + normal_pct + sp_numeric,
             })
             
-            neg_fig = px.bar(
+            neg_fig = px.line(
                 chart_df,
                 x="Threshold",
                 y="Percent",
                 color="Series",
-                barmode="group",
+                markers=True,
                 labels={"Percent": "% of years"},
             )
             neg_fig.update_layout(


### PR DESCRIPTION
Change the '% of years with extreme negative return' chart from a grouped bar chart to a line chart with markers, as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-976f7cc7-29af-47c1-9be8-0d06d9bdef37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-976f7cc7-29af-47c1-9be8-0d06d9bdef37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

