### PR TITLE
Show implied equity risk premium calculation

### DIFF
--- a/portfoliosimskewedt.py
+++ b/portfoliosimskewedt.py
@@ -430,7 +430,10 @@ def main():
                 min_value=-20.0, max_value=30.0,
                 value=_def_geom_mean_percent, step=0.1,
             )
+            # Display equity risk premium under stock return slider
             cash_return_percent = st.slider("Cash/Bond Return (%)", min_value=0.0, max_value=10.0, value=2.0, step=0.1)
+            erp_display_percent = float(stock_geom_mean_percent - cash_return_percent)
+            st.write(f"**Implied Equity Risk Premium (stock return - cash): {erp_display_percent:.2f}%**")
             inflation_rate_percent = st.slider("Inflation Mean (%)", min_value=0.0, max_value=10.0, value=2.5, step=0.1)
 
         with st.expander("Policy Options", expanded=True):

--- a/portfoliosimskewedt.py
+++ b/portfoliosimskewedt.py
@@ -430,10 +430,10 @@ def main():
                 min_value=-20.0, max_value=30.0,
                 value=_def_geom_mean_percent, step=0.1,
             )
-            # Display equity risk premium under stock return slider
             cash_return_percent = st.slider("Cash/Bond Return (%)", min_value=0.0, max_value=10.0, value=2.0, step=0.1)
-            erp_display_percent = float(stock_geom_mean_percent - cash_return_percent)
-            st.write(f"**Implied Equity Risk Premium (stock return - cash): {erp_display_percent:.2f}%**")
+            # Display equity risk premium under sliders
+            erp_geo_percent = float(stock_geom_mean_percent - cash_return_percent)
+            st.write(f"Implied Equity Risk Premium (stock return - cash): {erp_geo_percent:.2f}%")
             inflation_rate_percent = st.slider("Inflation Mean (%)", min_value=0.0, max_value=10.0, value=2.5, step=0.1)
 
         with st.expander("Policy Options", expanded=True):
@@ -441,10 +441,6 @@ def main():
             rebalance_each_year = st.checkbox("Rebalance annually", value=False)
 
         with st.expander("Advanced Options", expanded=False):
-            # Calculate equity risk premium for display
-            erp_geo_percent = float(stock_geom_mean_percent - cash_return_percent)
-            st.write(f"Implied Equity Risk Premium (stock return - cash): {erp_geo_percent:.2f}%")
-            
             inflation_vol_percent = st.slider("Inflation Vol (%)", min_value=0.0, max_value=5.0, value=1.5, step=0.1)
             cash_vol_percent = st.slider("Cash/Bond Vol (%)", min_value=0.0, max_value=5.0, value=1.5, step=0.1)
             stock_log_vol_percent = st.slider(


### PR DESCRIPTION
Move the "Implied Equity Risk Premium (stock return - cash)" display from "Advanced Options" to under the stock average return slider for better visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d6e5630-74f1-4b65-9b54-3d5d570f4c5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3d6e5630-74f1-4b65-9b54-3d5d570f4c5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

