### PR TITLE
Set singapore stock log volume to 20 percent

### DIFF
--- a/portfoliosimskewedt.py
+++ b/portfoliosimskewedt.py
@@ -452,6 +452,7 @@ def main():
                 st.session_state["stock_geom_mean_percent"] = 7.0
                 st.session_state["inflation_rate_percent"] = 1.7
                 st.session_state["cash_return_percent"] = 2.5
+                st.session_state["stock_log_vol_percent"] = 20.0
                 st.session_state["current_preset"] = "Singapore"
                 st.rerun()
         


### PR DESCRIPTION
Add `stock_log_vol_percent` to the Singapore preset to set stock log vol to 20 percent.

---
<a href="https://cursor.com/background-agent?bcId=bc-e2b107db-eba4-4748-ba54-05a5bbcc9fd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e2b107db-eba4-4748-ba54-05a5bbcc9fd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

