### PR TITLE
Debug percentile calculation in simulation

### DIFF
--- a/portfoliosimskewedt.py
+++ b/portfoliosimskewedt.py
@@ -408,7 +408,7 @@ def generate_simulation_results(
 
     # Percentile summary: show only 10%..90% percentiles, formatted as $ with thousands separators
     pct_levels = list(range(10, 100, 10))  # 10,20,...,90
-    pct_values = np.percentile(df["Final Real Value"].values, pct_levels)
+    pct_values = np.percentile(final_values, pct_levels)
     pct_rows = [f"{p}%" for p in pct_levels]
     pct_formatted = [f"${int(round(v)):,}" for v in pct_values]
     summary_percentiles_df = pd.DataFrame({"Outcome percentiles": pct_formatted}, index=pct_rows)


### PR DESCRIPTION
Fix `np.percentile` to use `final_values` directly because the `df` DataFrame was not in scope.

---
<a href="https://cursor.com/background-agent?bcId=bc-1f303315-6d7f-487a-bd34-0bc9f454b90c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1f303315-6d7f-487a-bd34-0bc9f454b90c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

